### PR TITLE
add ubuntu-20.04 to bcc-test.yml

### DIFF
--- a/.github/workflows/bcc-test.yml
+++ b/.github/workflows/bcc-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04] # 18.04.3 release has 5.0.0 kernel                                        
+        os: [ubuntu-18.04, ubuntu-20.04] # 18.04.3 release has 5.0.0 kernel                                         
         env:
         - TYPE: Debug
           PYTHON_TEST_LOGFILE: critical.log


### PR DESCRIPTION
`publish.yml` is using 20.04, so let's add it here as well

Need to migrate this to match libbpf's CI eventually

Signed-off-by: Dave Marchevsky <davemarchevsky@fb.com>